### PR TITLE
UI Feature: Terms of Service Screen

### DIFF
--- a/screens/Policies/PrivacyPolicy.jsx
+++ b/screens/Policies/PrivacyPolicy.jsx
@@ -1,59 +1,33 @@
 import { SafeAreaView, View, Text, TouchableOpacity, ScrollView, Modal } from "react-native"
-import { useState } from "react";
-import { useNavigation } from "@react-navigation/native";
-import { styles } from "./styles/privacy-policy-styles";
+import { styles } from "./styles/policy-styles";
 import { privayPolicyContent } from "./privacy-policy-contents";
 
 export default function PrivacyPolicy({ isVisible, onClose }) {
-    const navigation = useNavigation();
-    const [isChecked, setIsChecked] = useState(false);
-
-    // Go to the Register screen
-    const handleAccept = () => {
-        onClose()
-        navigation.navigate("Register");
-    }
-
-    // Go back to the Login screen
-    const handleBack = () => {
-        onClose()
-        navigation.navigate("Login");
-    }
-
     return (
         <Modal visible={isVisible} animationType="slide" transparent={true}>
 
-            <SafeAreaView style={styles.modalContainer}>
+            <SafeAreaView style={[styles.modalContainer, { backgroundColor: 'rgba(0, 0, 0, 0.1)', }]}>
                 <View style={styles.modalContent}>
                     {/* Header */}
                     <View style={styles.header}>
-                        <Text style={styles.privacyHeader}>Privacy Policy</Text>
+                        <Text style={styles.headerText}>Privacy Policy</Text>
                     </View>
 
                     {/* Body / Contents */}
                     <View style={styles.body}>
-                        <ScrollView style={styles.privacyContent}>
+                        <ScrollView style={styles.bodyContent}>
                             {privayPolicyContent.map(item => (
                                 <View key={item.id} style={styles.sectionContainer}>
                                     <Text style={styles.sectionTitle}>{item.section}</Text>
-                                    <Text style={styles.privacyText}>{item.content}</Text>
+                                    <Text style={styles.sectionText}>{item.content}</Text>
                                 </View>
                             ))}
-                            <View style={styles.checkboxContainer}>
-                                <TouchableOpacity style={styles.checkbox} onPress={() => setIsChecked(!isChecked)}>
-                                    {isChecked && <Text style={styles.checkmark}>✓</Text>}
-                                </TouchableOpacity>
-                                <Text style={styles.checkboxText}>I have read and agree to the Privacy Policy</Text>
-                            </View>
                         </ScrollView>
                     </View>
 
                     {/* Buttons */}
                     <View style={styles.buttonContainer}>
-                        <TouchableOpacity style={styles.acceptButton} onPress={handleAccept}>
-                            <Text style={styles.buttonText}>Accept</Text>
-                        </TouchableOpacity>
-                        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+                        <TouchableOpacity style={[styles.backButton, { backgroundColor: "#437456" }]} onPress={onClose}>
                             <Text style={styles.buttonText}>Go Back</Text>
                         </TouchableOpacity>
                     </View>

--- a/screens/Policies/TermsOfService.jsx
+++ b/screens/Policies/TermsOfService.jsx
@@ -1,10 +1,90 @@
-import { View, Text } from "react-native"
+import { SafeAreaView, View, Text, TouchableOpacity, ScrollView, Modal } from "react-native"
+import { useState } from "react";
+import { useNavigation } from "@react-navigation/native";
+import { styles } from "./styles/policy-styles";
+import { termsOfServiceContent } from "./terms-of-service-contents";
+import PrivacyPolicy from "./PrivacyPolicy";
 
-export default function TermsOfService() {
+export default function TermsOfService({ isVisible, onClose }) {
+    const navigation = useNavigation();
+    const [isChecked, setIsChecked] = useState(false);
+    const [showPrivacyPolicy, setShowPrivacyPolicy] = useState(false);
+
+    // Go to the Register screen
+    const handleAccept = () => {
+        if (isChecked) {
+            onClose()
+            navigation.navigate("Register");
+        } else {
+            alert("Please read and agree on the Terms of Service!");
+        }
+    }
+
+    // Go back to the Login screen
+    const handleBack = () => {
+        onClose()
+        navigation.navigate("Login");
+    }
+
+    // Show Privacy Policy modal
+    const linkToPrivacyPolicyModal = () => {
+        setShowPrivacyPolicy(true);
+    }
+
+    // CLose Privacy Policy modal
+    const closeLinkToPrivacyPolicyModal = () => {
+        setShowPrivacyPolicy(false);
+    }
+
     return (
-        <View>
-            <Text>Terms of Service</Text>
-        </View>
+        <Modal visible={isVisible} animationType="slide" transparent={true}>
+
+            <SafeAreaView style={styles.modalContainer}>
+                <View style={styles.modalContent}>
+                    {/* Header */}
+                    <View style={styles.header}>
+                        <Text style={styles.headerText}>Katiwala Terms of Service</Text>
+                    </View>
+
+                    {/* Body / Contents */}
+                    <View style={styles.body}>
+                        <ScrollView style={styles.bodyContent}>
+                            {termsOfServiceContent.map(item => (
+                                <View key={item.id} style={styles.sectionContainer}>
+                                    <Text style={styles.sectionTitle}>{item.section}</Text>
+                                    <Text style={styles.sectionText}>{item.content}</Text>
+                                </View>
+                            ))}
+
+                            <TouchableOpacity onPress={linkToPrivacyPolicyModal}>
+                                <Text style={styles.privacyPolicyLinkText}>Read Privacy Policy</Text>
+                            </TouchableOpacity>
+                            {/* Open this modal */}
+                            <PrivacyPolicy isVisible={showPrivacyPolicy} onClose={closeLinkToPrivacyPolicyModal} />
+
+                            <View style={styles.checkboxContainer}>
+                                <TouchableOpacity style={styles.checkbox} onPress={() => setIsChecked(!isChecked)}>
+                                    {isChecked && <Text style={styles.checkmark}>✓</Text>}
+                                </TouchableOpacity>
+                                <Text style={styles.checkboxText}>I have read and agree on this Terms</Text>
+                            </View>
+                        </ScrollView>
+                    </View>
+
+
+                    {/* Buttons */}
+                    <View style={styles.buttonContainer}>
+                        <TouchableOpacity style={styles.acceptButton} onPress={handleAccept}>
+                            <Text style={styles.buttonText}>Accept</Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity style={styles.backButton} onPress={handleBack}>
+                            <Text style={styles.buttonText}>Go Back</Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            </SafeAreaView>
+
+        </Modal>
     )
 }
 

--- a/screens/Policies/styles/policy-styles.js
+++ b/screens/Policies/styles/policy-styles.js
@@ -1,6 +1,7 @@
 import { StyleSheet } from "react-native";
 
 export const styles = StyleSheet.create({
+    /* Styles for Both Terms of Service and Privacy Policy */
     modalContainer: {
         flex: 1,
         justifyContent: 'center',
@@ -16,7 +17,7 @@ export const styles = StyleSheet.create({
         marginBottom: 10,
         alignItems: "center",
     },
-    privacyHeader: {
+    headerText: {
         fontSize: 24,
         fontFamily: "RobotoSlab_400Regular",
         textDecorationLine: "underline",
@@ -27,7 +28,7 @@ export const styles = StyleSheet.create({
         justifyContent: "center",
         alignItems: "center",
     },
-    privacyContent: {
+    bodyContent: {
         width: "90%",
         backgroundColor: "#E5E4E2",
         borderRadius: 10,
@@ -42,9 +43,33 @@ export const styles = StyleSheet.create({
         fontFamily: "RobotoSlab_400Regular",
         marginBottom: 8,
     },
-    privacyText: {
+    sectionText: {
         fontSize: 15,
         textAlign: "justify",
+    },
+    buttonContainer: {
+        marginHorizontal: 20,
+        marginBottom: 10,
+        gap: 8,
+    },
+    buttonText: {
+        textAlign: "center",
+        color: "white",
+        fontSize: 18,
+    },
+    backButton: {
+        backgroundColor: "red",
+        paddingHorizontal: 22,
+        paddingVertical: 10,
+        borderRadius: 10,
+    },
+    /* Styles only applicable for Terms of Service Screen */
+    privacyPolicyLinkText: {
+        color: "#437456",
+        textDecorationLine: "underline",
+        fontSize: 16,
+        fontWeight: "500",
+        fontStyle: "italic",
     },
     checkboxContainer: {
         flexDirection: "row",
@@ -66,22 +91,6 @@ export const styles = StyleSheet.create({
     },
     checkboxText: {
         fontSize: 15,
-    },
-    buttonContainer: {
-        marginHorizontal: 20,
-        marginBottom: 10,
-        gap: 8,
-    },
-    buttonText: {
-        textAlign: "center",
-        color: "white",
-        fontSize: 18,
-    },
-    backButton: {
-        backgroundColor: "red",
-        paddingHorizontal: 22,
-        paddingVertical: 10,
-        borderRadius: 10,
     },
     acceptButton: {
         backgroundColor: "#437456",

--- a/screens/Policies/terms-of-service-contents.js
+++ b/screens/Policies/terms-of-service-contents.js
@@ -1,0 +1,38 @@
+// ChatGPT Generate feel free to change the content of the termsOfServiceContent array to match the contents
+export const termsOfServiceContent = [
+    {
+        id: 1,
+        section: "Introduction",
+        content: "Welcome to Katiwala! These Terms of Service (“Terms”) govern your use of our website, products, and services. By accessing or using our services, you agree to be bound by these Terms."
+    },
+    {
+        id: 2,
+        section: "User Responsibilities",
+        content: "1. User Responsibilities\n- You are responsible for maintaining the confidentiality of your account and password and for restricting access to your account. You agree to accept responsibility for all activities that occur under your account.\n- You agree not to use our services for any illegal or unauthorized purpose, including but not limited to violating any laws in your jurisdiction."
+    },
+    {
+        id: 3,
+        section: "Intellectual Property",
+        content: "2. Intellectual Property\n- The content, trademarks, logos, and service marks displayed on our website are the property of Katiwala or its licensors. You agree not to reproduce, distribute, modify, or create derivative works of any such materials without our prior written consent."
+    },
+    {
+        id: 4,
+        section: "Limitation of Liability",
+        content: "3. Limitation of Liability\n- Katiwala shall not be liable for any indirect, incidental, special, consequential, or punitive damages, including but not limited to lost profits, arising out of or in connection with your use of our services."
+    },
+    {
+        id: 5,
+        section: "Indemnification",
+        content: "4. Indemnification\n- You agree to indemnify and hold harmless Katiwala and its affiliates, officers, directors, employees, and agents from any claims, liabilities, damages, costs, and expenses, including reasonable attorneys’ fees, arising out of or in connection with your use of our services or your violation of these Terms."
+    },
+    {
+        id: 6,
+        section: "Governing Law",
+        content: "5. Governing Law\n- These Terms shall be governed by and construed in accordance with the laws of [Your Jurisdiction], without regard to its conflict of law provisions."
+    },
+    {
+        id: 7,
+        section: "Changes to Terms",
+        content: "6. Changes to Terms\n- Katiwala reserves the right to update or modify these Terms at any time without prior notice. It is your responsibility to review these Terms periodically for changes. Your continued use of our services following the posting of any changes constitutes acceptance of those changes."
+    }
+]

--- a/screens/Register/index.jsx
+++ b/screens/Register/index.jsx
@@ -20,8 +20,8 @@ import { SecondaryButtonBGWhite } from "../Global components/GlobalButtons";
 import { newUserAtom } from "../../recoil/NewUserAtom";
 import { useRecoilState } from "recoil";
 
-// Privacy Policy Modal
-import PrivacyPolicy from "../Policies/PrivacyPolicy";
+// Terms of Service Modal
+import TermsOfService from "../Policies/TermsOfService";
 
 const Register = ({ navigation }) => {
   // const [date, setDate] = useState(new Date());
@@ -29,7 +29,7 @@ const Register = ({ navigation }) => {
   const [errorMessage, setErrorMessage] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [showVerifyPassword, setShowVerifyPassword] = useState(false);
-  const [showPrivacyPolicy, setShowPrivacyPolicy] = useState(true);
+  const [showTermsOfService, setShowTermsOfService] = useState(true);
 
   const [newUserData, setNewUserData] = useRecoilState(newUserAtom);
 
@@ -102,8 +102,8 @@ const Register = ({ navigation }) => {
     }
   };
 
-  const onClosePrivacyPolicyModal = () => {
-    setShowPrivacyPolicy(false);
+  const closeTermsOfServiceModal = () => {
+    setShowTermsOfService(false);
   }
 
   useEffect(() => {
@@ -121,7 +121,7 @@ const Register = ({ navigation }) => {
         }}
       >
 
-        <PrivacyPolicy isVisible={showPrivacyPolicy} onClose={onClosePrivacyPolicyModal} />
+        <TermsOfService isVisible={showTermsOfService} onClose={closeTermsOfServiceModal} />
 
         <View>
           <Text


### PR DESCRIPTION
To avoid redundancy bro @mgacrama211176 , some users kasi might think that terms of service and privacy policy are the same. But they are somewhat connected, so I used this approach instead. Nag lagay ako link for Reading Privacy Policy in the Terms of Service Modal screen. Kasi pag two separate screens and two separate authorization to accept the policies baka medyo hassle na sa users.

https://github.com/mgacrama211176/katiwala/assets/76894433/1933bb36-4a2d-42e5-9428-f6b2c7d9dffa

